### PR TITLE
Fix footer positioning to stick to bottom on short content pages

### DIFF
--- a/rnp/themes/chocos/assets/css/main.css
+++ b/rnp/themes/chocos/assets/css/main.css
@@ -29,6 +29,9 @@ body {
   font-kerning: normal;
   padding: 0;
   background-color: var(--color-background);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 .site-title {
   margin: 0;
@@ -45,6 +48,7 @@ header {
   max-width: 600px;
   margin: 0 auto;
   padding: 1rem;
+  flex: 1;
 }
 
 footer {


### PR DESCRIPTION
Implement CSS flexbox solution to ensure footer stays at bottom of viewport
  when page content is shorter than screen height. Changes:
  - Add flexbox layout to body (min-height: 100vh, display: flex, flex-direction: column)
  - Set main content area to flex: 1 to expand and push footer down
  - Maintains natural footer behavior on longer content page