### PR TITLE
Add Lists to top title bar

### DIFF
--- a/rnp/content/lists/_index.md
+++ b/rnp/content/lists/_index.md
@@ -1,0 +1,6 @@
+---
+title: Lists
+menu: 'main'
+---
+
+Lists and indexes collected in one place.


### PR DESCRIPTION
## Summary
- add a `Lists` section page at `rnp/content/lists/_index.md`
- register that section in the Hugo `main` menu
- expose `/lists/` in the top title bar navigation

## Testing
- `/home/chatting/.local/bin/hugo-rumandpopcorn --source /workspace/rumandpopcorn/rnp --destination /tmp/rumandpopcorn-public`

Closes #126
