### PR TITLE
Run PR CI on every pull request

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -3,11 +3,6 @@ name: PR CI
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'rnp/**'
-      - '.github/workflows/pr-ci.yml'
-      - '.go-version'
-      - '.hugo-version'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
The build-and-test job is a required check on PRs to main, but pr-ci.yml had a paths filter limiting it to rnp/**, .github/workflows/pr-ci.yml, .go-version, and .hugo-version. Any PR touching only other paths (e.g. Dependabot bumps under infra/, like #123) never triggered the workflow, so the required check stayed pending forever and the PR couldn't merge.

Dropping the filter is the simplest fix: the job is cheap and we'd rather run it unnecessarily than have PRs silently wedged. The alternative is making the check non-required or using a path-conditional skip job, both of which add more moving parts than this workflow warrants.