### PR TITLE
Add Little Boy Lost to 2026 books list

### DIFF
--- a/rnp/content/lists/books-2026.md
+++ b/rnp/content/lists/books-2026.md
@@ -36,3 +36,5 @@ date: 2026-01-01
    Little snippets and moments of quiet appreciation and small joy, from rose bushes to cups of tea. A calming read.
 1. **Percival Everett - So Much Blue**
    Three crises overlap in a story about secrets that's funny, tragic and moving.
+1. **Marghanita Laski - Little Boy Lost**
+   A powerful little story of a father seeking his son among the corruption of post war France.


### PR DESCRIPTION
## Summary
- add Marghanita Laski's Little Boy Lost to the 2026 books list
- keep the entry at the end so the list stays in chronological reading order

## Testing
- not run (content-only markdown change; no repo formatter configured)
