### PR TITLE
Generate Pagefind assets in Cloudflare Pages builds

### DIFF
--- a/infra/cloudflarepages.py
+++ b/infra/cloudflarepages.py
@@ -95,7 +95,7 @@ def build():
     rnp_site.repo_name = "rumandpopcorn"
     rnp_site.build_config = {
         "build_caching": True,
-        "build_command": "hugo",
+        "build_command": "hugo && npx -y pagefind --site public",
         "destination_dir": "/public",
         "root_dir": "/rnp",
     }


### PR DESCRIPTION
## Summary
- update the Cloudflare Pages build command to generate Pagefind assets during site builds
- make branch previews and production deploys use the same search asset generation step

## Why
The search PR references /pagefind assets, but the current Pages build command only runs hugo, so previews publish HTML without the generated Pagefind JS/CSS/index files.
