### PR TITLE
Add In Search of the Cities of Tomorrow to 2026 books

### DIFF
--- a/rnp/content/lists/books-2026.md
+++ b/rnp/content/lists/books-2026.md
@@ -38,3 +38,5 @@ date: 2026-01-01
    Three crises overlap in a story about secrets that's funny, tragic and moving.
 1. **Marghanita Laski - Little Boy Lost**
    A powerful little story of a father seeking his son among the corruption of post war France.
+1. **Des Fitzgerald - In Search of the Cities of Tomorrow**
+   Fascinating and funny tour of urban planning and 21st century thinking, but it does not offer many alternatives to the ideas it dismantles.

--- a/rnp/content/lists/books-2026.md
+++ b/rnp/content/lists/books-2026.md
@@ -38,5 +38,5 @@ date: 2026-01-01
    Three crises overlap in a story about secrets that's funny, tragic and moving.
 1. **Marghanita Laski - Little Boy Lost**
    A powerful little story of a father seeking his son among the corruption of post war France.
-1. **Des Fitzgerald - In Search of the Cities of Tomorrow**
+1. **Des Fitzgerald - The City of Today is a Dying Thing: In Search of the Cities of Tomorrow**
    Fascinating and funny tour of urban planning and 21st century thinking, but it does not offer many alternatives to the ideas it dismantles.


### PR DESCRIPTION
## Summary
- add Des Fitzgerald's In Search of the Cities of Tomorrow to the 2026 books list
- use Edward's supplied one-line note as the entry blurb
- keep the page's chronological ordering by appending the new entry at the end

## Testing
- not run locally: hugo is not installed in this container
