### PR TITLE
Stop sparse pages drifting right of the header

### DIFF
--- a/rnp/themes/chocos/assets/css/main.css
+++ b/rnp/themes/chocos/assets/css/main.css
@@ -45,7 +45,12 @@ header {
 }
 .main-col {
   line-height: 1.5;
-  max-width: 600px;
+  /* width + border-box stop <main> (a flex item) shrinking to its content
+     width, which otherwise centres sparse pages right of the header. The
+     max-width includes the padding so the content area stays 600px wide. */
+  width: 100%;
+  box-sizing: border-box;
+  max-width: calc(600px + 2rem);
   margin: 0 auto;
   padding: 1rem;
   flex: 1;


### PR DESCRIPTION
Pages with little content (sparse list pages especially) were sitting off to the right of the header instead of lining up under it. `.main-col` is a flex item, and with only `margin:0 auto` it shrank to its content width and centred itself in the flex row, so anything narrow drifted right.

The fix pins `.main-col` to the full column width while keeping the readable content area at 600px (the padding is folded into max-width). CSS-only, no content or layout-template changes.

Salvaged from some abandoned maps-section work. The maps themselves ended up on a separate private site, but this column-width fix is worth keeping on its own.